### PR TITLE
Upgrade alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 RUN apk add --no-cache curl jq docker
 


### PR DESCRIPTION
alpine v3.12 was released in 2020 and has many vulnerabilities:
![image](https://user-images.githubusercontent.com/43946230/174466506-6d152913-8add-4b87-bf1f-b8a710ab112d.png)
![image](https://user-images.githubusercontent.com/43946230/174466521-aabf4d83-afb2-4654-a569-a8089c5ea07c.png)
![image](https://user-images.githubusercontent.com/43946230/174466530-f1f09dda-2c93-4b95-879e-62491d5e575a.png)
